### PR TITLE
Fix local station names

### DIFF
--- a/LSTM/UIBalanceListEntry.cs
+++ b/LSTM/UIBalanceListEntry.cs
@@ -19,7 +19,7 @@ namespace LSTMMod
         {
             get
             {
-                string text = Util.GetStationName(station);
+                string text = Util.GetStationName(station, planetId);
                 if (string.IsNullOrEmpty(text))
                 {
                     text = station.isStellar ? ("星际站点号".Translate() + station.gid.ToString()) : ("本地站点号".Translate() + station.id.ToString());

--- a/LSTM/Util.cs
+++ b/LSTM/Util.cs
@@ -11,9 +11,12 @@ namespace LSTMMod
 {
     public static class Util
     {
-        public static string GetStationName(StationComponent station)
+        public static string GetStationName(StationComponent station, int planetId = 0)
         {
-            PlanetFactory pf = GameMain.galaxy.PlanetById(station.planetId)?.factory;
+            if(planetId == 0)
+                planetId = station.planetId;
+
+            PlanetFactory pf = GameMain.galaxy.PlanetById(planetId)?.factory;
             if (pf == null)
             {
                 return null;


### PR DESCRIPTION
Now PLS can show custom names on the Local list.
Previously, they would always say "Local Station #x".