### PR TITLE
Fix LSTM window layout on latest DSP

### DIFF
--- a/LSTM/MyWindowCtl.cs
+++ b/LSTM/MyWindowCtl.cs
@@ -85,6 +85,36 @@ namespace LSTMMod
             return win.GetComponent<RectTransform>();
         }
 
+        public static void SetWindowSize(ManualBehaviour win, Vector2 size)
+        {
+            RectTransform rectTransform = win.GetComponent<RectTransform>();
+            if (rectTransform == null)
+            {
+                return;
+            }
+
+            rectTransform.sizeDelta = size;
+            StretchChildToWindow(win, "panel-bg");
+            StretchChildToWindow(win, "shadow");
+        }
+
+        private static void StretchChildToWindow(ManualBehaviour win, string childName)
+        {
+            RectTransform rect = win.gameObject.transform.Find(childName) as RectTransform;
+            if (rect == null)
+            {
+                return;
+            }
+
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.pivot = new Vector2(0.5f, 0.5f);
+            rect.anchoredPosition3D = Vector3.zero;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+            rect.localScale = Vector3.one;
+        }
+
 
         public static void SetRect(ManualBehaviour win, RectTransform rect)
         {

--- a/LSTM/UIBalanceWindow.cs
+++ b/LSTM/UIBalanceWindow.cs
@@ -125,7 +125,7 @@ namespace LSTMMod
             MyWindowCtl.OpenWindow(this);
             if (windowTrans != null)
             {
-                windowTrans.sizeDelta = new Vector2(700, 640);
+                MyWindowCtl.SetWindowSize(this, new Vector2(700, 640));
             }
         }
 
@@ -137,7 +137,7 @@ namespace LSTMMod
             MyWindowCtl.OpenWindow(this);
             if (windowTrans != null)
             {
-                windowTrans.sizeDelta = new Vector2(700, 640);
+                MyWindowCtl.SetWindowSize(this, new Vector2(700, 640));
             }
         }
 
@@ -145,7 +145,7 @@ namespace LSTMMod
         {
             _eventLock = true;
             windowTrans = MyWindowCtl.GetRectTransform(this);
-            windowTrans.sizeDelta = new Vector2(700, 640);
+            MyWindowCtl.SetWindowSize(this, new Vector2(700, 640));
             balanceData = new BalanceData(0, 0, false, 0);
             displayModes = new DisplayMode[2];
             displayModes[0].useStationName = false;

--- a/LSTM/UIConfigWindow.cs
+++ b/LSTM/UIConfigWindow.cs
@@ -37,14 +37,14 @@ namespace LSTMMod
             MyWindowCtl.OpenWindow(this);
             if (windowTrans != null)
             {
-                windowTrans.sizeDelta = new Vector2(640f, 428f);
+                MyWindowCtl.SetWindowSize(this, new Vector2(640f, 428f));
             }
         }
 
         public override void _OnCreate()
         {
             windowTrans = MyWindowCtl.GetRectTransform(this);
-            windowTrans.sizeDelta = new Vector2(640f, 428f);
+            MyWindowCtl.SetWindowSize(this, new Vector2(640f, 428f));
 
             CreateUI();
         }

--- a/LSTM/UILogWindow.cs
+++ b/LSTM/UILogWindow.cs
@@ -78,7 +78,7 @@ namespace LSTMMod
             MyWindowCtl.OpenWindow(this);
             if (windowTrans != null)
             {
-                windowTrans.sizeDelta = WindowSize();
+                MyWindowCtl.SetWindowSize(this, WindowSize());
             }
         }
 
@@ -112,7 +112,7 @@ namespace LSTMMod
             _eventLock = true;
 
             windowTrans = MyWindowCtl.GetRectTransform(this);
-            windowTrans.sizeDelta = WindowSize();
+            MyWindowCtl.SetWindowSize(this, WindowSize());
 
             GameObject go = new GameObject("content");
             contentTrans = go.AddComponent<RectTransform>();
@@ -432,7 +432,7 @@ namespace LSTMMod
             MyWindowCtl.OpenWindow(this);
             if (windowTrans != null)
             {
-                windowTrans.sizeDelta = WindowSize();
+                MyWindowCtl.SetWindowSize(this, WindowSize());
             }
         }
 


### PR DESCRIPTION
Fixes the broken LSTM window layout on the latest game version.

Before:

<img width="600" alt="Broken LSTM window layout" src="https://github.com/user-attachments/assets/19b7aaf8-4756-4464-a016-29fb12ec6d1c" />

After:

<img width="600" alt="Fixed LSTM window layout" src="https://github.com/user-attachments/assets/8fa2ce96-943d-4d61-914a-eefd82c07974" />
